### PR TITLE
feat(extras): Add `PluginKey` to allow type-safe access to `Plugin.extras`.

### DIFF
--- a/examples/plugin_keys.py
+++ b/examples/plugin_keys.py
@@ -1,0 +1,46 @@
+import typing as t
+
+from disnake.ext import commands, plugins
+
+# `PluginKey`s provide a type-safe approach for interacting with
+# `Plugin.extras`, similar to aiohttp's `AppKey`s. This file is a
+# refactor of `extras.py` that uses `PluginKey`s instead of plain
+# strings, so it is advised to read `extras.py` first if you're not
+# familiar with extras yet.
+
+# Since we have two keys, "foo" and "bar", we define two `PluginKey`s
+# for them, with appropriate type arguments.
+
+foo_key = plugins.PluginKey[t.Literal["bar"]]("foo_key")
+bar_key = plugins.PluginKey[t.Literal["foo"]]("bar_key")
+
+# Be careful, as due to type system limitations the initial
+# `extras=...` cannot be type-validated.
+
+extras_plugin = plugins.Plugin(extras={"foo": "bar"})
+
+
+@extras_plugin.command()
+async def what_is_what(ctx: commands.Context[commands.Bot]):
+    await ctx.reply(str(extras_plugin.extras))
+
+
+# To get type-checking benefits, use square bracket notation on
+# `Plugin, as if it was a `dict`. Note, however, that only
+# `plugin[key]`, `plugin[key] = ...`, `del plugin[key]` and
+# `plugin.get()` are implemented, and `Plugin` is not a "real" `dict`.
+
+
+@extras_plugin.listener("on_message")
+async def swap_foobar(ctx: commands.Context[commands.Bot]):
+    if extras_plugin.get(foo_key):
+        del extras_plugin[foo_key]
+        extras_plugin[bar_key] = "foo"
+    else:
+        del extras_plugin[bar_key]
+        extras_plugin[foo_key] = "bar"
+
+    await ctx.reply("Done!")
+
+
+setup, teardown = extras_plugin.create_extension_handlers()

--- a/src/disnake/ext/plugins/plugin.py
+++ b/src/disnake/ext/plugins/plugin.py
@@ -19,12 +19,13 @@ if t.TYPE_CHECKING:
     from disnake.ext import tasks
 
 
-__all__ = ("Plugin", "PluginMetadata", "get_parent_plugin")
+__all__ = ("Plugin", "PluginMetadata", "get_parent_plugin", "PluginKey")
 
 LOGGER = logging.getLogger(__name__)
 _INVALID: t.Final[t.Sequence[str]] = (t.__file__, __file__)
 
 T = t.TypeVar("T")
+U = t.TypeVar("U")
 
 if sys.version_info < (3, 10):
     import typing_extensions
@@ -65,6 +66,15 @@ AppCommandCheck = t.Callable[[disnake.CommandInteraction], MaybeCoro[bool]]
 
 PrefixCommandCheckT = t.TypeVar("PrefixCommandCheckT", bound=PrefixCommandCheck)
 AppCommandCheckT = t.TypeVar("AppCommandCheckT", bound=AppCommandCheck)
+
+
+class PluginKey(str, t.Generic[T]):
+    """A :class:`str` subclass for type-safe access to :attr:`Plugin.extras`."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return f"<PluginKey name={str(self)!r}>"
 
 
 class CheckAware(t.Protocol):
@@ -433,6 +443,23 @@ class Plugin(t.Generic[BotT]):
     @extras.setter
     def extras(self, value: t.Dict[str, t.Any]) -> None:
         self.metadata.extras = value
+
+    # mutmap api
+
+    def __getitem__(self, key: PluginKey[T]) -> T:
+        return self.extras[key]
+
+    def __setitem__(self, key: PluginKey[T], value: T) -> None:
+        self.extras[key] = value
+
+    def __delitem__(self, key: PluginKey[t.Any]) -> None:
+        del self.extras[key]
+
+    def get(self, key: PluginKey[T], default: U = None) -> t.Union[T, U]:
+        """Type-safe method of calling ``plugin.extras.get`` directly."""
+        return self.extras.get(key, default)
+
+    # end mutmap api
 
     @property
     def commands(self) -> t.Sequence[commands.Command[Self, t.Any, t.Any]]:  # type: ignore


### PR DESCRIPTION
Supersedes #15 

`PluginKey` now exists and can be used with the new MutableMapping-like API on `Plugin` to access `.extras` keys in a type-safe manner, akin' to aiohttp's AppKey.
